### PR TITLE
Adding a backup URL option for resilient scraping.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ cache/
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# uv
+uv.lock

--- a/src/nyff_scraper/cli.py
+++ b/src/nyff_scraper/cli.py
@@ -9,7 +9,7 @@ import logging
 import sys
 from typing import Optional
 
-from .scraper import NYFFScraper
+from .scraper import NYFFScraper, DEFAULT_URL, DEFAULT_BACKUP_URL
 from .imdb_enricher import IMDbEnricher
 from .trailer_enricher import TrailerEnricher
 from .metadata_enricher import MetadataEnricher
@@ -30,7 +30,7 @@ def setup_argument_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  nyff-scraper                                          # Scrape default NYFF URL with all features
+  nyff-scraper                                         # Scrape default NYFF URL with all features
   nyff-scraper --url https://example.com/films         # Scrape custom URL
   nyff-scraper --only-scrape                           # Only scrape, no enrichment
   nyff-scraper --skip-trailers                         # Skip YouTube trailer search
@@ -43,8 +43,15 @@ Examples:
     parser.add_argument(
         'url',
         nargs='?',
-        default="https://www.filmlinc.org/nyff/nyff63-lineup/",
+        default=DEFAULT_URL,
         help='URL to scrape (default: NYFF 2025 lineup)'
+    )
+
+    parser.add_argument(
+        '--backup-url',
+        required=False,
+        default=DEFAULT_BACKUP_URL,
+        help='Backup URL in case primary fails (default: NYFF 2025 lineup on the Wayback Machine)'
     )
 
     # Processing options
@@ -167,7 +174,7 @@ def run_scraper_pipeline(args) -> int:
 
         # Step 1: Scrape film data
         print("Scraping NYFF film lineup...")
-        films = scraper.scrape_nyff_lineup(args.url, force_refresh=args.force_refresh_nyff)
+        films = scraper.scrape_nyff_lineup(args.url, args.backup_url, force_refresh=args.force_refresh_nyff)
 
         if not films:
             logger.error("No films found at the provided URL")

--- a/src/nyff_scraper/imdb_enricher.py
+++ b/src/nyff_scraper/imdb_enricher.py
@@ -59,8 +59,8 @@ class IMDbEnricher:
         
         # Strategy 1: Use advanced search with title and year filter (most reliable)
         advanced_search_url = f"https://www.imdb.com/search/title/?title={quote(clean_title)}&release_date={year}-01-01,{year}-12-31"
-        
-        filename = f"imdb_advanced_search_{re.sub(r'[^\w]', '_', film_title)}.html"
+        underscored_film_title = re.sub(r'[^\w]', '_', film_title)
+        filename = f"imdb_advanced_search_{underscored_film_title}.html"
         content = self.get_cached_or_fetch(advanced_search_url, filename)
         
         if content:
@@ -101,8 +101,8 @@ class IMDbEnricher:
         
         for attempt_num, search_query in enumerate(search_attempts, 1):
             search_url = f"https://www.imdb.com/find/?q={quote(search_query)}&s=tt&ttype=ft"
-            
-            filename = f"imdb_search_{re.sub(r'[^\w]', '_', film_title)}_attempt_{attempt_num}.html"
+            underscored_film_title = re.sub(r'[^\w]', '_', film_title)
+            filename = f"imdb_search_{underscored_film_title}_attempt_{attempt_num}.html"
             content = self.get_cached_or_fetch(search_url, filename)
             
             if not content:


### PR DESCRIPTION
* Adds a new argument (`--backup-url`) to the CLI, which can accept a backup URL for scraping the NYFF data. I ran into issues with NYFF's Cloudflare DNS blocking web requests, so I added a default fallback that uses the Wayback Machine's archive: https://web.archive.org/web/20250831221540/https://www.filmlinc.org/nyff/nyff63-lineup/

* Fixes a small bug with a backslash `/` being present in an F string that caused an error when underscoring the film titles for IMDB searches.

* Adding `uv.lock` to `.gitignore`. (I use `uv` for running the program).

Usage:
```
nyff-scraper --backup-url https://example.com
```